### PR TITLE
feat: add comprehensive test suite for embed-card package

### DIFF
--- a/packages/embed-card/package.json
+++ b/packages/embed-card/package.json
@@ -63,7 +63,8 @@
     "lint": "eslint",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
     "next-themes": "^0.3.0 || ^0.4.0",
@@ -81,11 +82,12 @@
     "access": "public"
   },
   "devDependencies": {
-    "next-themes": "^0.4.6",
-    "@types/react": "^19.2.10",
     "@1chooo/eslint-config": "workspace:*",
     "@1chooo/typescript-config": "workspace:*",
+    "@types/react": "^19.2.10",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.39.2",
+    "next-themes": "^0.4.6",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   }

--- a/packages/embed-card/src/providers.test.ts
+++ b/packages/embed-card/src/providers.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest"
+
+import { defaultProviders, createFallbackEmbed, createInvalidEmbed } from "./providers"
+import type { ResolvedEmbed } from "./types"
+
+/* ------------------------------------------------------------------ */
+/*  Helper                                                            */
+/* ------------------------------------------------------------------ */
+
+function resolveWith(urlStr: string, appearance?: "light" | "dark"): ResolvedEmbed | null {
+  const url = new URL(urlStr)
+  for (const p of defaultProviders) {
+    if (p.match(url)) {
+      return p.resolve(url, { appearance }) ?? null
+    }
+  }
+  return null
+}
+
+/* ------------------------------------------------------------------ */
+/*  createFallbackEmbed / createInvalidEmbed                          */
+/* ------------------------------------------------------------------ */
+
+describe("createFallbackEmbed", () => {
+  it("returns a link renderer with provider 'link'", () => {
+    const url = new URL("https://example.com/page")
+    const result = createFallbackEmbed(url)
+    expect(result.provider).toBe("link")
+    expect(result.renderer.type).toBe("link")
+    if (result.renderer.type === "link") {
+      expect(result.renderer.href).toBe("https://example.com/page")
+    }
+    expect(result.site).toBe("example.com")
+  })
+})
+
+describe("createInvalidEmbed", () => {
+  it("returns an invalid renderer with provider 'invalid'", () => {
+    const result = createInvalidEmbed("not a url")
+    expect(result.provider).toBe("invalid")
+    expect(result.renderer.type).toBe("invalid")
+    if (result.renderer.type === "invalid") {
+      expect(result.renderer.message).toContain("https://www.youtube.com/watch")
+    }
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  YouTube provider                                                  */
+/* ------------------------------------------------------------------ */
+
+describe("youtube provider", () => {
+  it("resolves ?v= URLs", () => {
+    const r = resolveWith("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    expect(r).not.toBeNull()
+    expect(r!.provider).toBe("youtube")
+    expect(r!.renderer.type).toBe("iframe")
+    if (r!.renderer.type === "iframe") {
+      expect(r!.renderer.src).toBe("https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0")
+    }
+  })
+
+  it("resolves youtu.be short links", () => {
+    const r = resolveWith("https://youtu.be/dQw4w9WgXcQ")
+    expect(r).not.toBeNull()
+    expect(r!.provider).toBe("youtube")
+    if (r!.renderer.type === "iframe") {
+      expect(r!.renderer.src).toContain("dQw4w9WgXcQ")
+    }
+  })
+
+  it("resolves /embed/ URLs", () => {
+    const r = resolveWith("https://www.youtube.com/embed/abc123")
+    expect(r).not.toBeNull()
+    if (r!.renderer.type === "iframe") {
+      expect(r!.renderer.src).toContain("abc123")
+    }
+  })
+
+  it("resolves /shorts/ URLs", () => {
+    const r = resolveWith("https://www.youtube.com/shorts/xyz789")
+    expect(r).not.toBeNull()
+    if (r!.renderer.type === "iframe") {
+      expect(r!.renderer.src).toContain("xyz789")
+    }
+  })
+
+  it("resolves /live/ URLs", () => {
+    const r = resolveWith("https://www.youtube.com/live/liveID")
+    expect(r).not.toBeNull()
+    if (r!.renderer.type === "iframe") {
+      expect(r!.renderer.src).toContain("liveID")
+    }
+  })
+
+  it("returns null for channel pages (no video ID)", () => {
+    const r = resolveWith("https://www.youtube.com/@channelName")
+    expect(r).toBeNull()
+  })
+
+  it("returns null for youtube.com root", () => {
+    const r = resolveWith("https://www.youtube.com/")
+    expect(r).toBeNull()
+  })
+
+  it("resolves m.youtube.com URLs", () => {
+    const r = resolveWith("https://m.youtube.com/watch?v=test123")
+    expect(r).not.toBeNull()
+    expect(r!.provider).toBe("youtube")
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Twitter / X provider                                              */
+/* ------------------------------------------------------------------ */
+
+describe("twitter provider", () => {
+  it("resolves x.com status URLs", () => {
+    const r = resolveWith("https://x.com/user/status/1234567890")
+    expect(r).not.toBeNull()
+    expect(r!.provider).toBe("twitter")
+    expect(r!.renderer.type).toBe("iframe")
+    if (r!.renderer.type === "iframe") {
+      expect(r!.renderer.src).toContain("id=1234567890")
+      expect(r!.renderer.src).toContain("theme=light")
+    }
+  })
+
+  it("resolves twitter.com status URLs", () => {
+    const r = resolveWith("https://twitter.com/someone/status/9876543210")
+    expect(r).not.toBeNull()
+    expect(r!.provider).toBe("twitter")
+  })
+
+  it("passes dark theme to embed URL", () => {
+    const r = resolveWith("https://x.com/user/status/123", "dark")
+    expect(r).not.toBeNull()
+    if (r!.renderer.type === "iframe") {
+      expect(r!.renderer.src).toContain("theme=dark")
+    }
+  })
+
+  it("returns null for profile URLs (no status ID)", () => {
+    const r = resolveWith("https://x.com/user")
+    expect(r).toBeNull()
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Reddit provider                                                   */
+/* ------------------------------------------------------------------ */
+
+describe("reddit provider", () => {
+  it("resolves /comments/ URLs to reddit_client renderer", () => {
+    const r = resolveWith("https://www.reddit.com/r/reactjs/comments/abc123/test_post/")
+    expect(r).not.toBeNull()
+    expect(r!.provider).toBe("reddit")
+    expect(r!.renderer.type).toBe("reddit_client")
+    if (r!.renderer.type === "reddit_client") {
+      // trailing slash should be stripped
+      expect(r!.renderer.postUrl).toBe(
+        "https://www.reddit.com/r/reactjs/comments/abc123/test_post"
+      )
+    }
+  })
+
+  it("resolves old.reddit.com URLs", () => {
+    const r = resolveWith("https://old.reddit.com/r/test/comments/xyz/title/")
+    expect(r).not.toBeNull()
+    expect(r!.provider).toBe("reddit")
+  })
+
+  it("returns null for subreddit root (no /comments/)", () => {
+    const r = resolveWith("https://www.reddit.com/r/reactjs/")
+    expect(r).toBeNull()
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Google Maps provider                                              */
+/* ------------------------------------------------------------------ */
+
+describe("google-maps provider", () => {
+  it("resolves google.com/maps URLs to iframe with output=embed", () => {
+    const r = resolveWith("https://www.google.com/maps/place/Eiffel+Tower")
+    expect(r).not.toBeNull()
+    expect(r!.provider).toBe("google-maps")
+    expect(r!.renderer.type).toBe("iframe")
+    if (r!.renderer.type === "iframe") {
+      expect(r!.renderer.src).toContain("output=embed")
+      expect(r!.renderer.src).toContain("Eiffel+Tower")
+    }
+  })
+
+  it("resolves maps.google.com URLs", () => {
+    const r = resolveWith("https://maps.google.com/maps?q=NYC")
+    expect(r).not.toBeNull()
+    expect(r!.provider).toBe("google-maps")
+  })
+
+  it("does not match non-maps google paths", () => {
+    const url = new URL("https://www.google.com/search?q=test")
+    const provider = defaultProviders.find((p) => p.id === "google-maps")!
+    expect(provider.match(url)).toBe(false)
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Vimeo provider                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("vimeo provider", () => {
+  it("resolves vimeo.com/ID URLs", () => {
+    const r = resolveWith("https://vimeo.com/12345678")
+    expect(r).not.toBeNull()
+    expect(r!.provider).toBe("vimeo")
+    expect(r!.renderer.type).toBe("iframe")
+    if (r!.renderer.type === "iframe") {
+      expect(r!.renderer.src).toBe("https://player.vimeo.com/video/12345678")
+    }
+  })
+
+  it("resolves player.vimeo.com/ID URLs", () => {
+    const r = resolveWith("https://player.vimeo.com/video/99999")
+    expect(r).not.toBeNull()
+    if (r!.renderer.type === "iframe") {
+      expect(r!.renderer.src).toContain("99999")
+    }
+  })
+
+  it("returns null for vimeo.com root (no video ID)", () => {
+    const r = resolveWith("https://vimeo.com/")
+    expect(r).toBeNull()
+  })
+
+  it("returns null for vimeo.com user profiles", () => {
+    const r = resolveWith("https://vimeo.com/user12345/about")
+    expect(r).toBeNull()
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  displayUrl truncation (via resolved embed)                        */
+/* ------------------------------------------------------------------ */
+
+describe("displayUrl", () => {
+  it("is ≤ 48 chars for short URLs", () => {
+    const r = resolveWith("https://vimeo.com/111")
+    expect(r).not.toBeNull()
+    expect(r!.displayUrl.length).toBeLessThanOrEqual(48)
+    expect(r!.displayUrl).toBe("vimeo.com/111")
+  })
+
+  it("is truncated to 48 chars with ellipsis for long URLs", () => {
+    const long =
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf&index=2"
+    const r = resolveWith(long)
+    expect(r).not.toBeNull()
+    expect(r!.displayUrl.length).toBe(48)
+    expect(r!.displayUrl.endsWith("...")).toBe(true)
+  })
+})

--- a/packages/embed-card/src/reddit-data.test.ts
+++ b/packages/embed-card/src/reddit-data.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  decodeRedditHtmlEntities,
+  formatRedditScore,
+  normalizeRedditPostUrl,
+  redditTimeAgo,
+} from "./reddit-data"
+
+/* ------------------------------------------------------------------ */
+/*  normalizeRedditPostUrl                                            */
+/* ------------------------------------------------------------------ */
+
+describe("normalizeRedditPostUrl", () => {
+  it("strips trailing slash", () => {
+    expect(normalizeRedditPostUrl("https://reddit.com/r/test/comments/abc/")).toBe(
+      "https://reddit.com/r/test/comments/abc"
+    )
+  })
+
+  it("trims whitespace", () => {
+    expect(normalizeRedditPostUrl("  https://reddit.com/r/test  ")).toBe(
+      "https://reddit.com/r/test"
+    )
+  })
+
+  it("leaves clean URLs untouched", () => {
+    expect(normalizeRedditPostUrl("https://reddit.com/r/test")).toBe(
+      "https://reddit.com/r/test"
+    )
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  decodeRedditHtmlEntities                                          */
+/* ------------------------------------------------------------------ */
+
+describe("decodeRedditHtmlEntities", () => {
+  it("replaces &amp; with &", () => {
+    expect(decodeRedditHtmlEntities("a&amp;b&amp;c")).toBe("a&b&c")
+  })
+
+  it("leaves strings without entities unchanged", () => {
+    expect(decodeRedditHtmlEntities("hello world")).toBe("hello world")
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  formatRedditScore                                                 */
+/* ------------------------------------------------------------------ */
+
+describe("formatRedditScore", () => {
+  it("returns raw number below 1000", () => {
+    expect(formatRedditScore(0)).toBe("0")
+    expect(formatRedditScore(42)).toBe("42")
+    expect(formatRedditScore(999)).toBe("999")
+  })
+
+  it("formats 1000+ as k with one decimal", () => {
+    expect(formatRedditScore(1000)).toBe("1.0k")
+    expect(formatRedditScore(1500)).toBe("1.5k")
+    expect(formatRedditScore(12345)).toBe("12.3k")
+    expect(formatRedditScore(100000)).toBe("100.0k")
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  redditTimeAgo                                                     */
+/* ------------------------------------------------------------------ */
+
+describe("redditTimeAgo", () => {
+  const NOW_SECONDS = 1700000000
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW_SECONDS * 1000)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("returns 'just now' for < 60s", () => {
+    expect(redditTimeAgo(NOW_SECONDS - 30)).toBe("just now")
+  })
+
+  it("returns minutes for 60s–3599s", () => {
+    expect(redditTimeAgo(NOW_SECONDS - 120)).toBe("2 min. ago")
+    expect(redditTimeAgo(NOW_SECONDS - 3599)).toBe("59 min. ago")
+  })
+
+  it("returns hours for 3600s–86399s", () => {
+    expect(redditTimeAgo(NOW_SECONDS - 3600)).toBe("1 hr. ago")
+    expect(redditTimeAgo(NOW_SECONDS - 7200)).toBe("2 hr. ago")
+  })
+
+  it("returns days for 86400s–2591999s", () => {
+    expect(redditTimeAgo(NOW_SECONDS - 86400)).toBe("1 days ago")
+    expect(redditTimeAgo(NOW_SECONDS - 604800)).toBe("7 days ago")
+  })
+
+  it("returns months for 2592000s–31535999s", () => {
+    expect(redditTimeAgo(NOW_SECONDS - 2592000)).toBe("1 mo. ago")
+    expect(redditTimeAgo(NOW_SECONDS - 7776000)).toBe("3 mo. ago")
+  })
+
+  it("returns years for ≥ 31536000s", () => {
+    expect(redditTimeAgo(NOW_SECONDS - 31536000)).toBe("1 yr. ago")
+    expect(redditTimeAgo(NOW_SECONDS - 63072000)).toBe("2 yr. ago")
+  })
+})

--- a/packages/embed-card/src/resolve-embed-providers.test.ts
+++ b/packages/embed-card/src/resolve-embed-providers.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveEmbed } from "./resolve"
+
+/**
+ * Integration tests — exercise resolveEmbed end-to-end through the
+ * full default provider chain for every supported provider.
+ */
+
+describe("resolveEmbed — cross-provider integration", () => {
+  /* ------ YouTube ------ */
+
+  it("YouTube: standard watch URL", () => {
+    const r = resolveEmbed("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    expect(r.provider).toBe("youtube")
+    expect(r.renderer.type).toBe("iframe")
+    if (r.renderer.type === "iframe") {
+      expect(r.renderer.src).toBe("https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0")
+      expect(r.renderer.aspectRatio).toBe("16 / 9")
+    }
+  })
+
+  it("YouTube: youtu.be short link", () => {
+    const r = resolveEmbed("https://youtu.be/dQw4w9WgXcQ")
+    expect(r.provider).toBe("youtube")
+    expect(r.renderer.type).toBe("iframe")
+  })
+
+  /* ------ Twitter / X ------ */
+
+  it("Twitter: x.com status URL", () => {
+    const r = resolveEmbed("https://x.com/elonmusk/status/1234567890123456789")
+    expect(r.provider).toBe("twitter")
+    expect(r.renderer.type).toBe("iframe")
+    if (r.renderer.type === "iframe") {
+      expect(r.renderer.src).toContain("1234567890123456789")
+    }
+  })
+
+  it("Twitter: twitter.com status URL", () => {
+    const r = resolveEmbed("https://twitter.com/user/status/999")
+    expect(r.provider).toBe("twitter")
+  })
+
+  /* ------ Instagram ------ */
+
+  it("Instagram: post permalink", () => {
+    const r = resolveEmbed("https://www.instagram.com/p/BR5ySLCBglt/")
+    expect(r.provider).toBe("instagram")
+    expect(r.renderer.type).toBe("iframe")
+    if (r.renderer.type === "iframe") {
+      expect(r.renderer.src).toContain("/embed/")
+    }
+  })
+
+  /* ------ Reddit ------ */
+
+  it("Reddit: thread URL", () => {
+    const r = resolveEmbed("https://www.reddit.com/r/reactjs/comments/abc123/my_post/")
+    expect(r.provider).toBe("reddit")
+    expect(r.renderer.type).toBe("reddit_client")
+    if (r.renderer.type === "reddit_client") {
+      expect(r.renderer.postUrl).not.toMatch(/\/$/)
+    }
+  })
+
+  /* ------ Google Maps ------ */
+
+  it("Google Maps: place URL", () => {
+    const r = resolveEmbed("https://www.google.com/maps/place/Eiffel+Tower")
+    expect(r.provider).toBe("google-maps")
+    expect(r.renderer.type).toBe("iframe")
+    if (r.renderer.type === "iframe") {
+      expect(r.renderer.src).toContain("output=embed")
+    }
+  })
+
+  /* ------ Vimeo ------ */
+
+  it("Vimeo: video URL", () => {
+    const r = resolveEmbed("https://vimeo.com/76979871")
+    expect(r.provider).toBe("vimeo")
+    expect(r.renderer.type).toBe("iframe")
+    if (r.renderer.type === "iframe") {
+      expect(r.renderer.src).toBe("https://player.vimeo.com/video/76979871")
+    }
+  })
+
+  /* ------ TikTok ------ */
+
+  it("TikTok: canonical video URL", () => {
+    const r = resolveEmbed("https://www.tiktok.com/@scout2015/video/6718335390845095173")
+    expect(r.provider).toBe("tiktok")
+    expect(r.renderer.type).toBe("iframe")
+  })
+
+  it("TikTok: vm.tiktok.com short link", () => {
+    const r = resolveEmbed("https://vm.tiktok.com/ZMabcdef123/")
+    expect(r.provider).toBe("tiktok")
+    expect(r.renderer.type).toBe("tiktok_client")
+  })
+
+  /* ------ Fallback ------ */
+
+  it("Fallback: unknown domain → link preview", () => {
+    const r = resolveEmbed("https://example.com/page")
+    expect(r.provider).toBe("link")
+    expect(r.renderer.type).toBe("link")
+    if (r.renderer.type === "link") {
+      expect(r.renderer.href).toBe("https://example.com/page")
+    }
+  })
+
+  /* ------ Invalid ------ */
+
+  it("Invalid: gibberish input", () => {
+    const r = resolveEmbed("not a url")
+    expect(r.provider).toBe("invalid")
+    expect(r.renderer.type).toBe("invalid")
+  })
+
+  it("Invalid: empty string", () => {
+    const r = resolveEmbed("")
+    expect(r.provider).toBe("invalid")
+  })
+})

--- a/packages/embed-card/src/resolve.test.ts
+++ b/packages/embed-card/src/resolve.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest"
+
+import { defaultProviders } from "./providers"
+import { resolveEmbed } from "./resolve"
+import type { EmbedProvider } from "./types"
+
+/* ------------------------------------------------------------------ */
+/*  parseUrl (tested indirectly through resolveEmbed)                 */
+/* ------------------------------------------------------------------ */
+
+describe("resolveEmbed — URL parsing", () => {
+  it("handles full URLs", () => {
+    const r = resolveEmbed("https://www.youtube.com/watch?v=abc")
+    expect(r.provider).toBe("youtube")
+  })
+
+  it("auto-prefixes schemeless domains with https://", () => {
+    const r = resolveEmbed("vimeo.com/12345")
+    expect(r.provider).toBe("vimeo")
+  })
+
+  it("trims surrounding whitespace", () => {
+    const r = resolveEmbed("  https://vimeo.com/12345  ")
+    expect(r.provider).toBe("vimeo")
+  })
+
+  it("returns invalid for gibberish input", () => {
+    const r = resolveEmbed("not-a-url at all")
+    expect(r.provider).toBe("invalid")
+    expect(r.renderer.type).toBe("invalid")
+  })
+
+  it("returns invalid for empty string", () => {
+    const r = resolveEmbed("")
+    expect(r.provider).toBe("invalid")
+  })
+
+  it("returns invalid for whitespace-only input", () => {
+    const r = resolveEmbed("   ")
+    expect(r.provider).toBe("invalid")
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Provider chain                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("resolveEmbed — provider chain", () => {
+  it("uses custom providers list when provided", () => {
+    const fakeProvider: EmbedProvider = {
+      id: "fake",
+      label: "Fake",
+      accentColor: "#000",
+      match: () => true,
+      resolve: (url) => ({
+        provider: "fake",
+        providerLabel: "Fake",
+        accentColor: "#000",
+        title: "Fake",
+        description: "Fake",
+        site: url.hostname,
+        url: url.toString(),
+        displayUrl: url.hostname,
+        renderer: { type: "invalid", message: "fake" },
+      }),
+    }
+
+    const r = resolveEmbed("https://www.youtube.com/watch?v=test", {
+      providers: [fakeProvider],
+    })
+    expect(r.provider).toBe("fake")
+  })
+
+  it("first-match wins when multiple providers could match", () => {
+    // YouTube is first in defaultProviders, so it should win
+    const r = resolveEmbed("https://www.youtube.com/watch?v=abc", {
+      providers: defaultProviders,
+    })
+    expect(r.provider).toBe("youtube")
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Fallback behaviour                                                */
+/* ------------------------------------------------------------------ */
+
+describe("resolveEmbed — fallback", () => {
+  it("returns link fallback for unrecognised URLs by default", () => {
+    const r = resolveEmbed("https://example.com/some-page")
+    expect(r.provider).toBe("link")
+    expect(r.renderer.type).toBe("link")
+  })
+
+  it("returns invalid when includeFallback is false", () => {
+    const r = resolveEmbed("https://example.com/page", { includeFallback: false })
+    expect(r.provider).toBe("invalid")
+    expect(r.renderer.type).toBe("invalid")
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Appearance context                                                */
+/* ------------------------------------------------------------------ */
+
+describe("resolveEmbed — appearance", () => {
+  it("passes appearance through to providers", () => {
+    const r = resolveEmbed("https://x.com/user/status/123", { appearance: "dark" })
+    expect(r.provider).toBe("twitter")
+    if (r.renderer.type === "iframe") {
+      expect(r.renderer.src).toContain("theme=dark")
+    }
+  })
+})

--- a/packages/embed-card/src/theme.test.ts
+++ b/packages/embed-card/src/theme.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createThemeVariables,
+  EMBED_CARD_DEFAULT_FONT_FAMILY,
+  EMBED_CARD_DEFAULT_SHADOW,
+  resolveEmbedCardAppearance,
+  variablesToInlineStyle,
+} from "./theme"
+
+/* ------------------------------------------------------------------ */
+/*  resolveEmbedCardAppearance                                        */
+/* ------------------------------------------------------------------ */
+
+describe("resolveEmbedCardAppearance", () => {
+  it("returns 'light' by default (no appearance set)", () => {
+    expect(resolveEmbedCardAppearance(undefined)).toBe("light")
+  })
+
+  it("returns 'light' when explicitly set", () => {
+    expect(resolveEmbedCardAppearance("light")).toBe("light")
+  })
+
+  it("returns 'dark' when explicitly set", () => {
+    expect(resolveEmbedCardAppearance("dark")).toBe("dark")
+  })
+
+  it("returns 'dark' for system + prefers dark", () => {
+    expect(resolveEmbedCardAppearance("system", true)).toBe("dark")
+  })
+
+  it("returns 'light' for system + prefers light", () => {
+    expect(resolveEmbedCardAppearance("system", false)).toBe("light")
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  createThemeVariables — light mode defaults                        */
+/* ------------------------------------------------------------------ */
+
+describe("createThemeVariables — light defaults", () => {
+  const vars = createThemeVariables({}, "light")
+
+  it("uses light accent color", () => {
+    expect(vars["--embed-card-accent"]).toBe("#111827")
+  })
+
+  it("sets light background", () => {
+    expect(vars["--embed-card-background"]).toContain("255")
+  })
+
+  it("uses default radius", () => {
+    expect(vars["--embed-card-radius"]).toBe("24px")
+  })
+
+  it("uses default shadow", () => {
+    expect(vars["--embed-card-shadow"]).toBe(EMBED_CARD_DEFAULT_SHADOW)
+  })
+
+  it("uses default font family", () => {
+    expect(vars["--embed-card-font-family"]).toBe(EMBED_CARD_DEFAULT_FONT_FAMILY)
+  })
+
+  it("uses white chrome tint", () => {
+    expect(vars["--embed-card-chrome-tint"]).toBe("#ffffff")
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  createThemeVariables — dark mode defaults                         */
+/* ------------------------------------------------------------------ */
+
+describe("createThemeVariables — dark defaults", () => {
+  const vars = createThemeVariables({}, "dark")
+
+  it("uses dark accent color", () => {
+    expect(vars["--embed-card-accent"]).toBe("#e2e8f0")
+  })
+
+  it("sets dark background", () => {
+    expect(vars["--embed-card-background"]).toContain("15")
+  })
+
+  it("uses dark chrome tint", () => {
+    expect(vars["--embed-card-chrome-tint"]).toBe("#0f172a")
+  })
+
+  it("uses dark preview canvas", () => {
+    expect(vars["--embed-card-preview-canvas"]).toBe("#0d1420")
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  createThemeVariables — custom overrides                           */
+/* ------------------------------------------------------------------ */
+
+describe("createThemeVariables — overrides", () => {
+  it("applies custom accentColor and derives border from it", () => {
+    const vars = createThemeVariables({ accentColor: "#ff0033" }, "light")
+    expect(vars["--embed-card-accent"]).toBe("#ff0033")
+    // border should be derived from the accent hex
+    expect(vars["--embed-card-border"]).toContain("rgba(255, 0, 51,")
+  })
+
+  it("applies numeric radius as px", () => {
+    const vars = createThemeVariables({ radius: 12 }, "light")
+    expect(vars["--embed-card-radius"]).toBe("12px")
+  })
+
+  it("applies string radius as-is", () => {
+    const vars = createThemeVariables({ radius: "1rem" }, "light")
+    expect(vars["--embed-card-radius"]).toBe("1rem")
+  })
+
+  it("applies custom shadow", () => {
+    const vars = createThemeVariables({ shadow: "0 4px 12px rgba(0,0,0,0.1)" }, "light")
+    expect(vars["--embed-card-shadow"]).toBe("0 4px 12px rgba(0,0,0,0.1)")
+  })
+
+  it("applies custom fontFamily", () => {
+    const vars = createThemeVariables({ fontFamily: '"Inter", sans-serif' }, "light")
+    expect(vars["--embed-card-font-family"]).toBe('"Inter", sans-serif')
+  })
+
+  it("falls back to mode default border for invalid hex accent", () => {
+    const vars = createThemeVariables({ accentColor: "notahex" }, "light")
+    // should fall through to the light default border
+    expect(vars["--embed-card-border"]).toContain("rgba(15, 23, 42,")
+  })
+
+  it("handles 3-char shorthand hex accent", () => {
+    const vars = createThemeVariables({ accentColor: "#f00" }, "light")
+    expect(vars["--embed-card-border"]).toContain("rgba(255, 0, 0,")
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  variablesToInlineStyle                                            */
+/* ------------------------------------------------------------------ */
+
+describe("variablesToInlineStyle", () => {
+  it("produces semicolon-separated key:value pairs", () => {
+    const vars = createThemeVariables({}, "light")
+    const style = variablesToInlineStyle(vars)
+
+    expect(style).toContain("--embed-card-accent:#111827")
+    expect(style).toContain(";")
+    // Should contain all 10 variables
+    const segments = style.split(";")
+    expect(segments.length).toBe(10)
+  })
+})

--- a/packages/embed-card/src/tiktok-embed-layout.test.ts
+++ b/packages/embed-card/src/tiktok-embed-layout.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  TIKTOK_EMBED_ASPECT_RATIO,
+  TIKTOK_EMBED_MAX_HEIGHT_PX,
+  TIKTOK_EMBED_MAX_WIDTH_PX,
+  TIKTOK_EMBED_MIN_HEIGHT_PX,
+  tiktokEmbedMaxHeightCss,
+} from "./tiktok-embed-layout"
+
+describe("tiktok-embed-layout constants", () => {
+  it("has expected aspect ratio", () => {
+    expect(TIKTOK_EMBED_ASPECT_RATIO).toBe("9 / 16")
+  })
+
+  it("has expected max width", () => {
+    expect(TIKTOK_EMBED_MAX_WIDTH_PX).toBe(420)
+  })
+
+  it("has expected max height", () => {
+    expect(TIKTOK_EMBED_MAX_HEIGHT_PX).toBe(480)
+  })
+
+  it("has expected min height", () => {
+    expect(TIKTOK_EMBED_MIN_HEIGHT_PX).toBe(280)
+  })
+})
+
+describe("tiktokEmbedMaxHeightCss", () => {
+  it("returns CSS min() combining px, vmin, and dvh", () => {
+    const css = tiktokEmbedMaxHeightCss()
+    expect(css).toBe("min(480px, 90vmin, 65dvh)")
+  })
+})

--- a/packages/embed-card/vitest.config.ts
+++ b/packages/embed-card/vitest.config.ts
@@ -4,5 +4,19 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/*.d.ts",
+        "src/embed-card.tsx",
+        "src/reddit-embed.tsx",
+        "src/reddit-shadow-dom.ts",
+        "src/tiktok-embed.tsx",
+        "src/next-themes.tsx",
+        "src/web-component.ts",
+      ],
+    },
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@types/react':
         specifier: ^19.2.10
         version: 19.2.14
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.13.4(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0))
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -348,6 +351,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -525,6 +532,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -1408,6 +1419,14 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1534,6 +1553,10 @@ packages:
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2386,6 +2409,15 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -2523,6 +2555,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2577,6 +2613,9 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -3004,6 +3043,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   eciesjs@0.4.18:
     resolution: {integrity: sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
@@ -3030,6 +3072,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -3372,6 +3417,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -3597,6 +3646,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -3714,6 +3768,9 @@ packages:
   hono@4.12.14:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -4009,9 +4066,28 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -4019,6 +4095,9 @@ packages:
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4197,6 +4276,9 @@ packages:
   lower-case@1.1.4:
     resolution: {integrity: sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -4211,6 +4293,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -4428,6 +4517,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
@@ -4657,6 +4750,9 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   param-case@2.1.1:
     resolution: {integrity: sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==}
 
@@ -4709,6 +4805,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -5254,6 +5354,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -5374,6 +5478,10 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -5792,6 +5900,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -5856,6 +5968,11 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -6087,6 +6204,8 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -6683,6 +6802,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.3
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6825,6 +6955,9 @@ snapshots:
   '@open-draft/until@2.1.0': {}
 
   '@orama/orama@3.1.18': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@radix-ui/number@1.1.1': {}
 
@@ -7671,6 +7804,25 @@ snapshots:
       vite: 6.4.2(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vue: 3.5.32(typescript@5.9.3)
 
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.13.4(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.13.4(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -7852,6 +8004,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -7928,6 +8082,12 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astring@1.9.0: {}
 
@@ -8324,6 +8484,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   eciesjs@0.4.18:
     dependencies:
       '@ecies/ciphers': 0.2.6(@noble/ciphers@1.3.0)
@@ -8343,6 +8505,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -8926,6 +9090,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -9141,6 +9310,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -9341,6 +9519,8 @@ snapshots:
       hermes-estree: 0.25.1
 
   hono@4.12.14: {}
+
+  html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
 
@@ -9613,6 +9793,27 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -9622,9 +9823,17 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@2.6.1: {}
 
   jose@6.2.2: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -9764,6 +9973,8 @@ snapshots:
 
   lower-case@1.1.4: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -9777,6 +9988,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
 
   markdown-extensions@2.0.0: {}
 
@@ -10252,6 +10473,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
@@ -10526,6 +10749,8 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.0.2
 
+  package-json-from-dist@1.0.1: {}
+
   param-case@2.1.1:
     dependencies:
       no-case: 2.3.2
@@ -10579,6 +10804,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
 
@@ -11246,6 +11476,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -11397,6 +11633,12 @@ snapshots:
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   through@2.3.8: {}
 
@@ -11858,6 +12100,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
- Add 6 new test files with 91 new tests (111 total)
- Unit tests for all 7 providers (YouTube, Twitter, Reddit, Google Maps, Vimeo, Instagram, TikTok)
- Unit tests for resolve.ts core orchestration, theme.ts CSS variable generation, reddit-data.ts utilities, tiktok-embed-layout.ts constants
- Integration tests exercising resolveEmbed end-to-end for all providers
- Configure V8 coverage reporting in vitest.config.ts
- Add test:coverage script and @vitest/coverage-v8 dev dependency

Closes #5